### PR TITLE
Update to 7.0.0 and add run_exports with upper_bound='x.x'

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: rocm-core
-  version: "6.4.3"
+  version: "7.0.1"
 
 package:
   name: ${{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: "https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-${{ version }}.tar.gz"
-    sha256: dae6e06739882a3ce7be13ac300c22ab35ce80b4e853a21a1a3237fdc0411eb9
+    sha256: d35b0a11b888bea9bbd6c87150f46ea709d8aa943a635d6f4d2a69fc9be5ab8d
 
 build:
   number: 0
@@ -21,6 +21,8 @@ requirements:
     - ${{ compiler('cxx') }}
     - cmake
     - ninja
+  run_exports:
+    - ${{ pin_subpackage(name, upper_bound='x.x') }}
 
 tests:
   - requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - traversaro
+    - isuruf


### PR DESCRIPTION
Part of https://github.com/conda-forge/conda-forge.github.io/issues/1923#issuecomment-3324588344 .

This PR updates `rocm-core` to version 7.0.1, and adds `run_exports` with `upper_bound='x.x'`. 

The idea of adding  `upper_bound='x.x'` is that we could use `rocm-core` as amd packaging guidelines suggest (see https://github.com/ROCm/rocm-core/blob/rocm-7.0.1/README.md):

> It is also important to note that ROCM-CORE takes the role as a base component on which all of ROCm can depend, to make it easy to remove all of ROCm with a package manager.

My idea (if other rocm mantainers like @isuruf and @zklaus agree) is to take the occasion of the rocm 7 transition, to start adding `rocm-core {{ version }}` as a host dependency to all the rocm packages. In this way, we both align with AMD packaging, and also we can use `rocm-core` as a sort of selector package to select a given rocm version, and prevent packages from different rocm `<major>.<minor>` version to be installed in the same environment. In a way, this would make `rocm-core` similar to what the role played by the [`cuda-version` package](https://github.com/conda-forge/cuda-version-feedstock/tree/99a6514f1125bbccfedf7cd878aebbc60f8bb31b/recipe) for cuda. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
