### PR TITLE
Bump version to 7.2.1 and switch to rocm-systems tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About rocm-core-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/rocm-core-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/ROCm/rocm-core
+Home: https://github.com/ROCm/rocm-systems
 
 Package license: MIT
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,14 +1,14 @@
 context:
   name: rocm-core
-  version: "7.1.0"
+  version: "7.2.1"
 
 package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-  - url: "https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-${{ version }}.tar.gz"
-    sha256: 3c7e990ff4da60119c8575982660331bf636f63a9c68c6a344d410b2bdfa5d39
+  - url: "https://github.com/ROCm/rocm-systems/releases/download/rocm-${{ version }}/rocm-core.tar.gz"
+    sha256: 372221919ca31accb1e6567acf21062d56b93b8df0c25ab3e7a9ab15c331578e
 
 build:
   number: 0
@@ -39,7 +39,7 @@ tests:
         - rocm-core
 
 about:
-  homepage: https://github.com/ROCm/rocm-core
+  homepage: https://github.com/ROCm/rocm-systems
   license: MIT
   license_family: MIT
   license_file: LICENSE.md


### PR DESCRIPTION
This PR bumps the version of rocm-core to 7.2.1, and switches to use the project-specific tarball provided by the new rocm-systems monorepo.

The recipe is extracted from https://github.com/gbionics/rock-the-conda/pull/26 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
